### PR TITLE
Add Example for checkbox property based on /inst/ask-checkbox.png

### DIFF
--- a/inst/README.md
+++ b/inst/README.md
@@ -64,6 +64,8 @@ ask(
 	}, filter = as.integer),
   toppings = choose("What about the topping?",
     c("Peperonni and cheese", "All dressed", "Hawaïan")),
+  toppings_extra = checkbox("Extra toppings?",
+    c("Peperonni", "Ham", "Extra Cheese", "Olives", "Mushrooms", "Chilis")),
   beverage = choose("You also get a free 2L beverage",
     c("Pepsi", "7up", "Coke")),
   comments = input("Any comments about your purchase experience?",


### PR DESCRIPTION
I was missing the checkbox function in the example code of the README.md:

I added the line based on the items in the screenshot: https://github.com/gaborcsardi/ask#checkbox-select-multiple-values-from-a-list

![missing-checkbox](https://user-images.githubusercontent.com/9831678/144427177-7a8ecc10-c1e8-4bea-a8d2-8c5f8a4466ed.gif)
